### PR TITLE
Gameplay optimizations. Part 1

### DIFF
--- a/client/src/block/block.c
+++ b/client/src/block/block.c
@@ -59,7 +59,7 @@ void Block_BuildDefinition(void) {
     Block_definition[15].lightType = BlockLightType_Emit;
 
     Block_Define(16, "lava", 15, 15, 15);
-    Block_definition[16].colliderType = BlockColliderType_None;
+    Block_definition[16].colliderType = BlockColliderType_Liquid;
     Block_definition[16].lightType = BlockLightType_Emit;
 
     Block_Define(17, "stone_slab", 1, 1, 1);

--- a/client/src/block/block.c
+++ b/client/src/block/block.c
@@ -43,11 +43,15 @@ void Block_BuildDefinition(void) {
     Block_definition[12].modelType = BlockModelType_Sprite;
     Block_definition[12].renderType = BlockRenderType_Transparent;
     Block_definition[12].colliderType = BlockColliderType_None;
+    Block_definition[12].minBB = (Vector3) {4, 0, 4};
+    Block_definition[12].maxBB = (Vector3) {12, 10, 12};
     
     Block_Define(13, "dandelion", 13, 13, 13);
     Block_definition[13].modelType = BlockModelType_Sprite;
     Block_definition[13].renderType = BlockRenderType_Transparent;
     Block_definition[13].colliderType = BlockColliderType_None;
+    Block_definition[13].minBB = (Vector3) {4, 0, 4};
+    Block_definition[13].maxBB = (Vector3) {12, 10, 12};
     
     Block_Define(14, "glass", 17, 17, 17);
     Block_definition[14].renderType = BlockRenderType_Transparent;

--- a/client/src/block/blockMeshGeneration.c
+++ b/client/src/block/blockMeshGeneration.c
@@ -126,18 +126,18 @@ void BlockMesh_AddFace(unsigned char *vertices, unsigned short *indices, unsigne
         if(b.modelType != BlockModelType_Sprite) {
             switch(face) {
                 case BlockFace_Bottom:
-                    colors[BFH_colorsI[translucent]++] = fmin(100, fmax(16, 100 - light));
+                    colors[BFH_colorsI[translucent]++] = fmin(100, fmax(32, 100 - light));
                     break;
                 case BlockFace_Left:
                 case BlockFace_Right:
-                    colors[BFH_colorsI[translucent]++] = fmin(150, fmax(16, 150 - light));
+                    colors[BFH_colorsI[translucent]++] = fmin(150, fmax(32, 150 - light));
                     break;
                 case BlockFace_Front:
                 case BlockFace_Back:
-                    colors[BFH_colorsI[translucent]++] = fmin(200, fmax(16, 200 - light));
+                    colors[BFH_colorsI[translucent]++] = fmin(200, fmax(32, 200 - light));
                     break;
                 default:
-                    colors[BFH_colorsI[translucent]++] = fmin(255, fmax(16, 255 - light));
+                    colors[BFH_colorsI[translucent]++] = fmin(255, fmax(32, 255 - light));
                     break;
             }
         } else {

--- a/client/src/gui/screens.c
+++ b/client/src/gui/screens.c
@@ -87,20 +87,20 @@ void Screen_MakeGame(void) {
     int texY = texI / 16 * 16;
 
     Rectangle texRec = (Rectangle) {
-        texX, 
-        texY, 
-        texX + 16, 
-        texY + 16
+        texX + 16 - blockDef.maxBB.x, 
+        texY + 16 - blockDef.maxBB.y, 
+        (blockDef.maxBB.x - blockDef.minBB.x), 
+        (blockDef.maxBB.y - blockDef.minBB.y)
     };
 
     Rectangle destRec = (Rectangle) { 
-        screenWidth - 80 - (blockDef.minBB.x * 4), 
+        screenWidth - 80 + (blockDef.minBB.x * 4), 
         16 + ((16 - blockDef.maxBB.y) * 4), 
         (blockDef.maxBB.x - blockDef.minBB.x) * 4, 
         (blockDef.maxBB.y - blockDef.minBB.y) * 4
     };
 
-    DrawTextureTiled(mapTerrain, texRec, destRec, (Vector2) {0, 0}, 0, 4, WHITE);
+    DrawTexturePro(mapTerrain, texRec, destRec, (Vector2) {0, 0}, 0, WHITE);
 
     //Draw Chat
     Chat_Draw((Vector2){16, screenHeight - 52}, uiColBg);

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -88,7 +88,7 @@ int main(void) {
                 if(player.rayResult.hitBlockID != -1) {
                     Block block = Block_GetDefinition(player.rayResult.hitBlockID);
                     Vector3 blockSize = Vector3Subtract(block.maxBB, block.minBB);
-                    blockSize = Vector3Scale(block.maxBB, 1.0f / 16);
+                    blockSize = Vector3Scale(blockSize, 1.0f / 16);
                     selectionBoxPos.y += blockSize.y / 2;
                     DrawCube(selectionBoxPos, blockSize.x + 0.01f, blockSize.y + 0.01f, blockSize.z + 0.01f, (Color){255, 255, 255, 40});
                 }

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -10,6 +10,7 @@
 #include <math.h>
 #include <pthread.h>
 #include <raylib.h>
+#include <raymath.h>
 #include "rlgl.h"
 #include "player.h"
 #include "world.h"
@@ -75,7 +76,7 @@ int main(void) {
         Player_Update();
         World_UpdateChunks();
         
-        Vector3 selectionBoxPos = (Vector3) { floor(player.rayResult.hitPos.x) + 0.5f, floor(player.rayResult.hitPos.y) + 0.5f, floor(player.rayResult.hitPos.z) + 0.5f};
+        Vector3 selectionBoxPos = (Vector3) { floor(player.rayResult.hitPos.x) + 0.5f, floor(player.rayResult.hitPos.y), floor(player.rayResult.hitPos.z) + 0.5f};
         
         // Draw
         BeginDrawing();
@@ -84,8 +85,14 @@ int main(void) {
 
             BeginMode3D(player.camera);
                 World_Draw(player.camera.position);
-                if(player.rayResult.hitBlockID != -1) 
-                    DrawCube(selectionBoxPos, 1.01f, 1.01f, 1.01f, (Color){255, 255, 255, 40});
+                if(player.rayResult.hitBlockID != -1) {
+                    Block block = Block_GetDefinition(player.rayResult.hitBlockID);
+                    Vector3 blockSize = Vector3Subtract(block.maxBB, block.minBB);
+                    blockSize = Vector3Scale(block.maxBB, 1.0f / 16);
+                    selectionBoxPos.y += blockSize.y / 2;
+                    DrawCube(selectionBoxPos, blockSize.x + 0.01f, blockSize.y + 0.01f, blockSize.z + 0.01f, (Color){255, 255, 255, 40});
+                }
+                    
             EndMode3D();
             
             Screen_Make();

--- a/client/src/player.c
+++ b/client/src/player.c
@@ -249,12 +249,11 @@ void Player_Update() {
     //Move X & Test Collisions
     for(int i = 0; i < steps; i++) {
         player.position.x += velXdt.x / steps;
-        if(Player_TestCollision()) {
+            if (Player_TestCollision()) {
             if (player.velocity.y != 0 || Player_TestSemiCollision()) {
                 player.position.x -= velXdt.x / steps;
-            }
-            else {
-                player.position.y += 0.51f / steps;
+                } else {
+                    player.position.y += 0.1f / steps;
             }
         }
     }
@@ -262,12 +261,13 @@ void Player_Update() {
     //Move Z & Test Collisions
     for(int i = 0; i < steps; i++) {
         player.position.z += velXdt.z / steps;
-            if(Player_TestCollision()) {
+            if (Player_TestCollision()) {
                 if (player.velocity.y != 0 || Player_TestSemiCollision()) {
                     player.position.z -= velXdt.z / steps;
+                } else {
+                    player.position.y += 0.1f / steps;
+                    break;
                 }
-                else {
-                    player.position.y += 0.51f / steps;
             }
         }
     }

--- a/client/src/player.c
+++ b/client/src/player.c
@@ -50,8 +50,8 @@ void Player_Init() {
 
 void Player_CheckInputs() {
     
-    if(IsKeyPressed(KEY_ESCAPE)) {
-        if(Screen_cursorEnabled) {
+    if (IsKeyPressed(KEY_ESCAPE)) {
+        if (Screen_cursorEnabled) {
             DisableCursor();
             Chat_open = false;
             Screen_Switch(SCREEN_GAME);
@@ -60,8 +60,8 @@ void Player_CheckInputs() {
             Screen_Switch(SCREEN_PAUSE);
         }
         Screen_cursorEnabled = !Screen_cursorEnabled;
-    } else if(IsKeyPressed(KEY_T)) {
-        if(Screen_cursorEnabled && !Chat_open) {
+    } else if (IsKeyPressed(KEY_T)) {
+        if (Screen_cursorEnabled && !Chat_open) {
             DisableCursor();
             Screen_cursorEnabled = false;
             Screen_Switch(SCREEN_GAME);
@@ -81,7 +81,7 @@ void Player_CheckInputs() {
     
     Player_oldMousePos = GetMousePosition();
     
-    if(!Screen_cursorEnabled) {
+    if (!Screen_cursorEnabled) {
         Player_cameraAngle.x -= (mousePositionDelta.x * -MOUSE_SENSITIVITY);
         Player_cameraAngle.y -= (mousePositionDelta.y * -MOUSE_SENSITIVITY);
         
@@ -89,9 +89,9 @@ void Player_CheckInputs() {
         float maxCamAngleY = PI - 0.01f;
         float minCamAngleY = 0.01f;
         
-        if(Player_cameraAngle.y >= maxCamAngleY) 
+        if (Player_cameraAngle.y >= maxCamAngleY) 
             Player_cameraAngle.y = maxCamAngleY;
-        else if(Player_cameraAngle.y <= minCamAngleY) 
+        else if (Player_cameraAngle.y <= minCamAngleY) 
             Player_cameraAngle.y = minCamAngleY;
     }
     
@@ -110,30 +110,30 @@ void Player_CheckInputs() {
     float forwardY = cy;
     float forwardZ = sx * sy;
     
-    if(!Screen_cursorEnabled) {
+    if (!Screen_cursorEnabled) {
         //Handle keys & mouse
-        if(IsKeyDown(KEY_SPACE) && player.canJump) {
+        if (IsKeyDown(KEY_SPACE) && player.canJump) {
             player.velocity.y += 0.2f;
             player.canJump = false;
         }
         Vector3 moveDir = { 0 };
         
-        if(IsKeyDown(KEY_W)) {
+        if (IsKeyDown(KEY_W)) {
             moveDir.z += sx;
             moveDir.x += cx;
         }
         
-        if(IsKeyDown(KEY_S)) {
+        if (IsKeyDown(KEY_S)) {
             moveDir.z -= sx;
             moveDir.x -= cx;
         }
         
-        if(IsKeyDown(KEY_A)) {
+        if (IsKeyDown(KEY_A)) {
             moveDir.z -= sx90;
             moveDir.x -= cx90;
         }
         
-        if(IsKeyDown(KEY_D)) {
+        if (IsKeyDown(KEY_D)) {
             moveDir.z += sx90;
             moveDir.x += cx90;
         }
@@ -143,22 +143,22 @@ void Player_CheckInputs() {
         player.velocity = Vector3Add(player.velocity, moveVel);
         
         float wheel = GetMouseWheelMove();
-        if(wheel > 0.35f) player.blockSelected++;
-        if(wheel < -0.35f) player.blockSelected--;
-        if(player.blockSelected > 18) player.blockSelected = 1;
-        if(player.blockSelected < 1) player.blockSelected = 18;
+        if (wheel > 0.35f) player.blockSelected++;
+        if (wheel < -0.35f) player.blockSelected--;
+        if (player.blockSelected > 18) player.blockSelected = 1;
+        if (player.blockSelected < 1) player.blockSelected = 18;
         
         player.rayResult = Raycast_Do(player.camera.position, (Vector3) { forwardX, forwardY, forwardZ}, true);
 
-        if(IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) { //Break Block
-            if(player.rayResult.hitBlockID != -1) {
+        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) { //Break Block
+            if (player.rayResult.hitBlockID != -1) {
                 World_SetBlock(player.rayResult.hitPos, 0, true);
                 Network_Send(Packet_SetBlock(0, player.rayResult.hitPos));
             }
-        } else if(IsMouseButtonPressed(MOUSE_RIGHT_BUTTON)) { //Place Block
+        } else if (IsMouseButtonPressed(MOUSE_RIGHT_BUTTON)) { //Place Block
             Vector3 placePos = Vector3Add(player.rayResult.hitPos, player.rayResult.normal);
 
-            if(player.rayResult.hitBlockID != -1) {
+            if (player.rayResult.hitBlockID != -1) {
             switch (player.blockSelected)
             {
                 case -1: // null
@@ -190,7 +190,7 @@ void Player_CheckInputs() {
                     break;
                 }
             }
-        } else if(IsMouseButtonPressed(MOUSE_BUTTON_MIDDLE)) { //Pick Block
+        } else if (IsMouseButtonPressed(MOUSE_BUTTON_MIDDLE)) { //Pick Block
             int pickedID = World_GetBlock(player.rayResult.hitPos);
             player.blockSelected = pickedID;
         }
@@ -207,7 +207,7 @@ bool Player_TryPlaceBlock(Vector3 pos, int blockID)
 {
     int oldBlock = World_GetBlock(pos);
     World_SetBlock(pos, blockID, true);
-    if (Player_TestCollision())
+    if (Player_TestCollision((Vector3){ 0 }))
     {
         World_SetBlock(pos, oldBlock, true);
         return false;
@@ -223,7 +223,7 @@ void Player_Update() {
 
     //Gravity
     player.velocity.y -= 0.012f * (GetFrameTime() * 60);
-    if(player.velocity.y <= -1) player.velocity.y = -1;
+    if (player.velocity.y <= -1) player.velocity.y = -1;
     
     //Calculate velocity with delta time
     Vector3 velXdt = Vector3Scale(player.velocity, GetFrameTime() * 60);
@@ -234,11 +234,11 @@ void Player_Update() {
 
 
     //Move Y & Test Collisions
-    for(int i = 0; i < steps; i++) {
+    for (int i = 0; i < steps; i++) {
         player.position.y += velXdt.y / steps;
-        if(Player_TestCollision()) {
+        if (Player_TestCollision((Vector3){ 0 })) {
             player.position.y -= velXdt.y / steps;
-            if(player.velocity.y <= 0) player.canJump = true;
+            if (player.velocity.y <= 0) player.canJump = true;
             player.velocity.y = 0;
             break;
         } else {
@@ -247,34 +247,33 @@ void Player_Update() {
     }
 
     //Move X & Test Collisions
-    for(int i = 0; i < steps; i++) {
+    for (int i = 0; i < steps; i++) {
         player.position.x += velXdt.x / steps;
-            if (Player_TestCollision()) {
-            if (player.velocity.y != 0 || Player_TestSemiCollision()) {
+        if (Player_TestCollision((Vector3){ 0 })) {
+            if (player.velocity.y != 0 || Player_TestCollision((Vector3){0,0.51f,0})) {
                 player.position.x -= velXdt.x / steps;
-                } else {
-                    player.position.y += 0.1f / steps;
+            } else {
+                player.position.y += 0.1f / steps;
             }
         }
     }
 
     //Move Z & Test Collisions
-    for(int i = 0; i < steps; i++) {
+    for (int i = 0; i < steps; i++) {
         player.position.z += velXdt.z / steps;
-            if (Player_TestCollision()) {
-                if (player.velocity.y != 0 || Player_TestSemiCollision()) {
-                    player.position.z -= velXdt.z / steps;
-                } else {
-                    player.position.y += 0.1f / steps;
-                    break;
-                }
+        if (Player_TestCollision((Vector3){ 0 })) {
+            if (player.velocity.y != 0 || Player_TestCollision((Vector3){0,0.51f,0})) {
+                player.position.z -= velXdt.z / steps;
+            } else {
+                player.position.y += 0.1f / steps;
+                break;
             }
         }
     }
 
-    if(floor(oldPosition.x / 16) != floor(player.position.x / 16) || 
-       floor(oldPosition.y / 16) != floor(player.position.y / 16) ||
-       floor(oldPosition.z / 16) != floor(player.position.z / 16)) {
+    if (floor(oldPosition.x / 16) != floor(player.position.x / 16) || 
+        floor(oldPosition.y / 16) != floor(player.position.y / 16) ||
+        floor(oldPosition.z / 16) != floor(player.position.z / 16)) {
         World_LoadChunks();
     }
 
@@ -290,30 +289,30 @@ void Player_Update() {
     Player_CheckInputs(); 
 }
 
-bool Player_TestCollision() {
+bool Player_TestCollision(Vector3 offset) {
     
     BoundingBox pB = player.collisionBox;
-    pB.min = Vector3Add(pB.min, player.position);
-    pB.max = Vector3Add(pB.max, player.position);
+    pB.min = Vector3Add(Vector3Add(pB.min, player.position), offset);
+    pB.max = Vector3Add(Vector3Add(pB.max, player.position), offset);
     
-    for(int x = (int)(pB.min.x - 1); x < (int)(pB.max.x + 1); x++) {
-        for(int z = (int)(pB.min.z - 1); z < (int)(pB.max.z + 1); z++) {
-            for(int y = (int)(pB.min.y - 1); y < (int)(pB.max.y + 1); y++) {
+    for (int x = (int)(pB.min.x - 1); x < (int)(pB.max.x + 1); x++) {
+        for (int z = (int)(pB.min.z - 1); z < (int)(pB.max.z + 1); z++) {
+            for (int y = (int)(pB.min.y - 1); y < (int)(pB.max.y + 1); y++) {
                 
                 Vector3 blockPos = (Vector3) {x, y, z};
                 Vector3 chunkPos = (Vector3) { floor(blockPos.x / CHUNK_SIZE_X), floor(blockPos.y / CHUNK_SIZE_Y), floor(blockPos.z / CHUNK_SIZE_Z) };
                 Chunk* chunk = World_GetChunkAt(chunkPos);
-                if(chunk == NULL || chunk->isMapGenerated == false) return true;
+                if (chunk == NULL || chunk->isMapGenerated == false) return true;
 
                 int blockID = World_GetBlock(blockPos);
                 Block blockDef = Block_GetDefinition(blockID);
-                if(blockDef.colliderType != BlockColliderType_Solid) continue;
+                if (blockDef.colliderType != BlockColliderType_Solid) continue;
                 
                 BoundingBox blockB;
                 blockB.min = (Vector3) {x + (blockDef.minBB.x / 16), y + (blockDef.minBB.y / 16), z + (blockDef.minBB.z / 16)};
                 blockB.max = (Vector3) {x + (blockDef.maxBB.x / 16), y + (blockDef.maxBB.y / 16), z + (blockDef.maxBB.z / 16)};
                 
-                if(CheckCollisionBoxes(pB, blockB)) return true;
+                if (CheckCollisionBoxes(pB, blockB)) return true;
             }
         }
     }
@@ -321,36 +320,6 @@ bool Player_TestCollision() {
     return false;
 }
 
-bool Player_TestSemiCollision() {
-    
-    BoundingBox pB = player.collisionBox;
-    pB.min = Vector3Add(Vector3Add(pB.min, player.position), (Vector3){0,0.51f,0});
-    pB.max = Vector3Add(Vector3Add(pB.max, player.position), (Vector3){0,0.51f,0});
-    
-    for(int x = (int)(pB.min.x - 1); x < (int)(pB.max.x + 1); x++) {
-        for(int z = (int)(pB.min.z - 1); z < (int)(pB.max.z + 1); z++) {
-            for(int y = (int)(pB.min.y - 1); y < (int)(pB.max.y + 1); y++) {
-                
-                Vector3 blockPos = (Vector3) {x, y, z};
-                Vector3 chunkPos = (Vector3) { floor(blockPos.x / CHUNK_SIZE_X), floor(blockPos.y / CHUNK_SIZE_Y), floor(blockPos.z / CHUNK_SIZE_Z) };
-                Chunk* chunk = World_GetChunkAt(chunkPos);
-                if(chunk == NULL || chunk->isMapGenerated == false) return true;
-
-                int blockID = World_GetBlock(blockPos);
-                Block blockDef = Block_GetDefinition(blockID);
-                if(blockDef.colliderType != BlockColliderType_Solid) continue;
-                
-                BoundingBox blockB;
-                blockB.min = (Vector3) {x + (blockDef.minBB.x / 16), y + (blockDef.minBB.y / 16), z + (blockDef.minBB.z / 16)};
-                blockB.max = (Vector3) {x + (blockDef.maxBB.x / 16), y + (blockDef.maxBB.y / 16), z + (blockDef.maxBB.z / 16)};
-                
-                if(CheckCollisionBoxes(pB, blockB)) return true;
-            }
-        }
-    }
-    
-    return false;
-}
 
 Vector3 Player_GetForwardVector(void) {
     float cx = cosf(Player_cameraAngle.x);

--- a/client/src/player.c
+++ b/client/src/player.c
@@ -158,6 +158,7 @@ void Player_CheckInputs() {
         } else if(IsMouseButtonPressed(MOUSE_RIGHT_BUTTON)) { //Place Block
             Vector3 placePos = Vector3Add(player.rayResult.hitPos, player.rayResult.normal);
 
+            if(player.rayResult.hitBlockID != -1) {
             switch (player.blockSelected)
             {
                 case -1: // null
@@ -187,6 +188,7 @@ void Player_CheckInputs() {
                 default:
                     Player_TryPlaceBlock(placePos, player.blockSelected);
                     break;
+                }
             }
         } else if(IsMouseButtonPressed(MOUSE_BUTTON_MIDDLE)) { //Pick Block
             int pickedID = World_GetBlock(player.rayResult.hitPos);

--- a/client/src/player.c
+++ b/client/src/player.c
@@ -38,7 +38,7 @@ void Player_Init() {
     player.position = (Vector3) { 0, 80, 0 };
     player.speed = 0.125f / 6;
     
-    player.collisionBox.min = (Vector3) { 0, 0, 0 };
+    player.collisionBox.min = (Vector3) { 0.2f, 0, 0.2f };
     player.collisionBox.max = (Vector3) { 0.8f, 1.5f, 0.8f };
 
     player.blockSelected = 15;

--- a/client/src/player.c
+++ b/client/src/player.c
@@ -18,6 +18,7 @@
 #include "block/block.h"
 #include "networking/networkhandler.h"
 #include "networking/packet.h"
+#include "vectormath.h"
 
 #define MOUSE_SENSITIVITY 0.003f
 
@@ -115,26 +116,31 @@ void Player_CheckInputs() {
             player.velocity.y += 0.2f;
             player.canJump = false;
         }
+        Vector3 moveDir = { 0 };
         
         if(IsKeyDown(KEY_W)) {
-            player.velocity.z += sx * player.speed;
-            player.velocity.x += cx * player.speed;
+            moveDir.z += sx;
+            moveDir.x += cx;
         }
         
         if(IsKeyDown(KEY_S)) {
-           player.velocity.z -= sx * player.speed;
-           player.velocity.x -= cx * player.speed;
+            moveDir.z -= sx;
+            moveDir.x -= cx;
         }
         
         if(IsKeyDown(KEY_A)) {
-           player.velocity.z -= sx90 * player.speed;
-           player.velocity.x -= cx90 * player.speed;
+            moveDir.z -= sx90;
+            moveDir.x -= cx90;
         }
         
         if(IsKeyDown(KEY_D)) {
-           player.velocity.z += sx90 * player.speed;
-           player.velocity.x += cx90 * player.speed;
+            moveDir.z += sx90;
+            moveDir.x += cx90;
         }
+
+        moveDir = Vector3ClampValue(moveDir, 0.0f, 1.0f); // normalize
+        Vector3 moveVel = Vector3Scale(moveDir, player.speed);
+        player.velocity = Vector3Add(player.velocity, moveVel);
         
         float wheel = GetMouseWheelMove();
         if(wheel > 0.35f) player.blockSelected++;

--- a/client/src/player.c
+++ b/client/src/player.c
@@ -217,6 +217,8 @@ void Player_Update() {
             if(player.velocity.y <= 0) player.canJump = true;
             player.velocity.y = 0;
             break;
+        } else {
+            player.canJump = false;
         }
     }
 

--- a/client/src/player.h
+++ b/client/src/player.h
@@ -34,6 +34,7 @@ void Player_CheckInputs(void);
 void Player_Update(void);
 
 bool Player_TestCollision(void);
+bool Player_TestSemiCollision(void);
 Vector3 Player_GetForwardVector(void);
 
 #endif

--- a/client/src/player.h
+++ b/client/src/player.h
@@ -35,8 +35,7 @@ void Player_Update(void);
 
 bool Player_TryPlaceBlock(Vector3 pos, int blockID);
 
-bool Player_TestCollision(void);
-bool Player_TestSemiCollision(void);
+bool Player_TestCollision(Vector3 offset);
 Vector3 Player_GetForwardVector(void);
 
 #endif

--- a/client/src/player.h
+++ b/client/src/player.h
@@ -33,6 +33,8 @@ void Player_CheckInputs(void);
 //Update a player.
 void Player_Update(void);
 
+bool Player_TryPlaceBlock(Vector3 pos, int blockID);
+
 bool Player_TestCollision(void);
 bool Player_TestSemiCollision(void);
 Vector3 Player_GetForwardVector(void);

--- a/client/src/raycast.c
+++ b/client/src/raycast.c
@@ -7,13 +7,16 @@
 
 #include "raycast.h"
 #include "raylib.h"
+#include "raymath.h"
 #include "world.h"
 #include "math.h"
+#include "block/block.h"
+#include <stdio.h>
 
 #define RAYCAST_PRECISION 0.05f
 #define RAYCAST_REACH 8
 
-RaycastResult Raycast_Do(Vector3 position, Vector3 direction) {
+RaycastResult Raycast_Do(Vector3 position, Vector3 direction, bool ignoreLiquid) {
     float i = 0;
     Vector3 oldPos = position;
     
@@ -27,10 +30,64 @@ RaycastResult Raycast_Do(Vector3 position, Vector3 direction) {
         
         int blockID = World_GetBlock(position);
         
+        
         if(blockID != 0) {
-            return (RaycastResult) {position, oldPos, blockID};
+            Block block = Block_GetDefinition(blockID);
+            if (ignoreLiquid && block.colliderType == BlockColliderType_Liquid) {
+                continue;
+            }
+            Vector3 blockPos = (Vector3){floor(position.x), floor(position.y), floor(position.z)};
+            if (position.x > blockPos.x + block.minBB.x / 16 &&
+                position.y > blockPos.y + block.minBB.y / 16 &&
+                position.z > blockPos.z + block.minBB.z / 16 &&
+                position.x < blockPos.x + block.maxBB.x / 16 &&
+                position.y < blockPos.y + block.maxBB.y / 16 &&
+                position.z < blockPos.z + block.maxBB.z / 16) {
+                Vector3 loc = Vector3Subtract(position, Vector3Add(blockPos, Vector3Scale(block.minBB, 1.0f / 16)));
+                Vector3 bbSize = Vector3Scale(block.maxBB, 1.0f / 16);
+                float entryX = -loc.x;
+                if (loc.x > bbSize.x - loc.x)
+                    entryX = bbSize.x - loc.x;
+                
+                float entryY = -loc.y;
+                if (loc.y > bbSize.y - loc.y)
+                    entryY = bbSize.y - loc.y;
+                
+                float entryZ = -loc.z;
+                if (loc.z > bbSize.z - loc.z)
+                    entryZ = bbSize.z - loc.z;
+                
+                Vector3 normal = (Vector3){0,0,0};
+                
+                if (fabs(entryX) < fabs(entryY)) {
+                    if (fabs(entryX) < fabs(entryZ)) {
+                        normal.x = (entryX > 0) ? 1 : ((entryX < 0) ? -1 : 0);
+                        normal.y = 0.0f;
+                        normal.z = 0.0f;
+                    } else {
+                        normal.z = (entryZ > 0) ? 1 : ((entryZ < 0) ? -1 : 0);
+                        normal.x = 0.0f;
+                        normal.y = 0.0f;
+                    }
+                } else {
+                    if (fabs(entryY) < fabs(entryZ)) {
+                        normal.y = (entryY > 0) ? 1 : ((entryY < 0) ? -1 : 0);
+                        normal.x = 0.0f;
+                        normal.z = 0.0f;
+
+                    } else {
+                        normal.z = (entryZ > 0) ? 1 : ((entryZ < 0) ? -1 : 0);
+                        normal.x = 0.0f;
+                        normal.y = 0.0f;
+                    }
+                }
+                
+                return (RaycastResult) {position, oldPos, blockID, normal};
+            }
+            else
+                continue;
         }
     }
     
-    return (RaycastResult) {position, oldPos, -1};
+    return (RaycastResult) {position, oldPos, -1, (Vector3){0,0,0}};
 }

--- a/client/src/raycast.c
+++ b/client/src/raycast.c
@@ -11,7 +11,6 @@
 #include "world.h"
 #include "math.h"
 #include "block/block.h"
-#include <stdio.h>
 
 #define RAYCAST_PRECISION 0.05f
 #define RAYCAST_REACH 8
@@ -29,7 +28,6 @@ RaycastResult Raycast_Do(Vector3 position, Vector3 direction, bool ignoreLiquid)
         position.z += direction.z * RAYCAST_PRECISION;
         
         int blockID = World_GetBlock(position);
-        
         
         if(blockID != 0) {
             Block block = Block_GetDefinition(blockID);

--- a/client/src/raycast.h
+++ b/client/src/raycast.h
@@ -14,9 +14,10 @@ typedef struct RaycastResult {
     Vector3 hitPos;
     Vector3 prevPos;
     int hitBlockID;
+    Vector3 normal;
 } RaycastResult;
 
-RaycastResult Raycast_Do(Vector3 position, Vector3 direction);
+RaycastResult Raycast_Do(Vector3 position, Vector3 direction, bool ignoreLiquid);
 
 
 #endif

--- a/client/src/vectormath.h
+++ b/client/src/vectormath.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2021-2022 Sirvoid
+ * 
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+#ifndef G_VECTORMATH_H
+#define G_VECTORMATH_H
+
+#include "raylib.h"
+#include "raymath.h"
+
+/**
+ * WARNING!! 
+ * This code is a copy of the code from the Raylib codebase,
+ * which has not yet been included in the official release.
+ * It may be unstable.
+ * Each function has a link to the original code located on Github.
+ * The code will be deleted after the original code gets into the stable release.
+ */
+
+// https://github.com/raysan5/raylib/blob/4a9391ae83757afd86b6f1cccae4335c611b5b41/src/raymath.h#L952
+Vector3 Vector3ClampValue(Vector3 v, float min, float max)
+{
+    Vector3 result = { 0 };
+
+    float length = (v.x*v.x) + (v.y*v.y) + (v.z*v.z);
+    if (length > 0.0f)
+    {
+        length = sqrtf(length);
+
+        if (length < min)
+        {
+            float scale = min/length;
+            result.x = v.x*scale;
+            result.y = v.y*scale;
+            result.z = v.z*scale;
+        }
+        else if (length > max)
+        {
+            float scale = max/length;
+            result.x = v.x*scale;
+            result.y = v.y*scale;
+            result.z = v.z*scale;
+        }
+        else 
+        {
+            return v;
+        }
+    }
+
+    return result;
+}
+
+#endif


### PR DESCRIPTION
A small but large list of improvements:
1. Slabs. Now the player jumps on them automatically. (Fix #4)
2. You can now put another half-block on the half-block and then they will be replaced with an alternative block. 
3. The raycast now also returns normal. This added a lot of opportunities and saved from unpleasant consequences. However, the raycast may still work somewhat incorrectly on the edges of the blocks. 
4. The raycast additionally checks whether it has hit the block.
5. Now the raycast has the `ignoreLiquid` parameter, which allows you to ignore liquid blocks. Now this is quite enough, but in the future you will most likely have to use something like a mask. 
6. _In fact, this is a continuation of 2._ Now you can choose the block installation logic for each block. As an example, now flowers can only be placed on the ground, grass or sand. 
7. Now, after placed block, there is a check for a collision of the block with the player. 
8. The player can no longer jump while in the air. 
9. Player movement is now normalized. Previously, the player could move faster by holding down 2 keys.
10. Fixed the size of the player's collider. (Fix #5)
11. The maximum shadow is now not so dark. (Part #2)
12. Lava now has `colliderType = BlockColliderType_Liquid`

_Also, some things that worked well before my changes were made were corrected. In addition, I had to copy some of the code from the raylib master branch, since they should appear only in a future version (I needed the `Vector3ClampValue()` function, which is not in raylib 4.0.0)._

![image](https://user-images.githubusercontent.com/5556081/179912688-17548a46-5e6e-4351-a325-01cab550b70b.png)

https://user-images.githubusercontent.com/5556081/179912794-a7540868-f210-4bb6-8abd-e711fae7e692.mp4


